### PR TITLE
Fix logo path

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -75,8 +75,7 @@ localisation:
   availableLanguages:
     - it
   localisationReady: false
-logo: |-
-  https://raw.githubusercontent.com/ComuneDiRivoli/parlaConIO/master/screenshots/logo.png
+logo: screenshots/logo.png
 maintenance:
   contacts:
     - affiliation: Comune di Rivoli


### PR DESCRIPTION
Buongiorno @franthemanIT,

ho apportato una leggera modifica al file `publiccode.yml` per rendere il path del logo relativo alla root del repository. 
Questo faciliterà l'import nel catalogo.

A disposizione
Grazie molte