### PR TITLE
Add codiceIPA to publiccode.yml file

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -56,6 +56,8 @@ intendedAudience:
     - local-authorities
     - education
 it:
+  riuso:
+    codiceIPA: c_h355
   conforme:
     gdpr: false
     lineeGuidaDesign: false


### PR DESCRIPTION
Buongiorno @franthemanIT,

purtroppo la validazione non è andata a buon fine a causa di un mismatch tra il codiceIPA dichiarato in fase di onboarding e quello trovato nel `publiccode.yml` (in questo momento non c'è). Il `codiceIPA` è un campo obbligatorio in caso di software di titolarità della PA. Questo è un controllo che l'editor online non può fare ma viene effettuato a backend dal crawler. 
Fatta questa modifica domani mattina il software sarà a catalogo. 

Grazie molte